### PR TITLE
Draft components relying on reactive propagation

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,12 +1,9 @@
 <script setup lang="ts">
-// This starter template is using Vue 3 <script setup> SFCs
-// Check out https://v3.vuejs.org/api/sfc-script-setup.html#sfc-script-setup
-import HelloWorld from './components/HelloWorld.vue'
+import Root from "./extra/components/Root.vue";
 </script>
 
 <template>
-  <img alt="Vue logo" src="./assets/logo.png" />
-  <HelloWorld msg="Hello Vue 3 + TypeScript + Vite" />
+  <Root />
 </template>
 
 <style>

--- a/src/extra/cache.ts
+++ b/src/extra/cache.ts
@@ -1,0 +1,106 @@
+// inspired by, modelled on React-Query
+// e.g. see https://dev.to/otamnitram/react-query-a-practical-example-167j
+
+// union below shows cache states in approximate time order
+type Cache<T> = Readonly<
+| {
+    // no value has ever been pending, cache is empty
+    isLoading: false;
+    data?: never;
+    error?: never;
+  }
+| {
+    // value is pending
+    isLoading: true;
+    data?: T; //previous, stale value (if available)
+    error?: never; // no error, data is pending
+  }
+| {
+    // no value is pending, last pending value was a success
+    isLoading: false;
+    data: T;
+    error?: never;
+  }
+| {
+    // no value is pending, last pending value was a failure
+    isLoading: false;
+    data?: T; //previous, stale value (if available)
+    error: unknown; // an error WAS thrown, use type guards to identify and handle it
+  }
+>;
+
+// An outer container that can be monitored in a 'reactive' framework e.g. using Vue, Pinia, MobX, Lauf
+export interface CacheContainer<T> {
+cache: Cache<T>;
+}
+
+/** Correctly initialise a cache container. */
+export function initialiseCacheContainer<T>(
+initialData?: T,
+): CacheContainer<T> {
+return initialData
+  ? {
+      cache: {
+        isLoading: false,
+        data: initialData,
+      },
+    }
+  : {
+      cache: {
+        isLoading: false,
+      },
+    };
+}
+
+/** Updates a CacheContainer<T> to track the loading of a Promise<T>. The mutation
+* of container properties will trigger reactive logic, hence updating components
+* bound to the container state.*/
+export async function populateCache<T>(
+container: CacheContainer<T>,
+valuePromise: Promise<T>,
+): Promise<void> {
+// inspect state
+const {
+  cache: { isLoading, data },
+} = container;
+// error if load is pending
+if (isLoading) {
+  throw new Error('Load already in progress');
+}
+// notify loading
+// populate stale if available
+if (data) {
+  container.cache = {
+    isLoading: true,
+    data,
+  };
+} else {
+  container.cache = {
+    isLoading: true,
+  };
+}
+// complete the load
+try {
+  const value = await valuePromise;
+  // unset loading flag, populate value
+  container.cache = {
+    isLoading: false,
+    data: value,
+  };
+} catch (error) {
+  // unset loading flag
+  const { data } = container.cache;
+  if (data) {
+    container.cache = {
+      isLoading: false,
+      data,
+      error,
+    };
+  } else {
+    container.cache = {
+      isLoading: false,
+      error,
+    };
+  }
+}
+}

--- a/src/extra/components/Branch.vue
+++ b/src/extra/components/Branch.vue
@@ -1,0 +1,19 @@
+<template>
+  <Leaf :dog-image-url="dogImageUrl" />
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+import Leaf from "./Leaf.vue";
+export default defineComponent({
+  components: {
+    Leaf,
+  },
+  props: {
+    dogImageUrl: {
+      type: URL,
+      required: true,
+    },
+  },
+});
+</script>

--- a/src/extra/components/Leaf.vue
+++ b/src/extra/components/Leaf.vue
@@ -1,0 +1,15 @@
+<template>
+  <img :src="dogImageUrl.toString()" />
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+export default defineComponent({
+  props: {
+    dogImageUrl: {
+      type: URL,
+      required: true,
+    },
+  },
+});
+</script>

--- a/src/extra/components/Root.vue
+++ b/src/extra/components/Root.vue
@@ -1,0 +1,35 @@
+<template>
+  <Branch v-if="displayableImageUrl" :dog-image-url="displayableImageUrl" />
+</template>
+
+<script lang="ts">
+import { computed, defineComponent } from "vue";
+import { populateCache } from "../cache";
+import { getRandomImageUrl } from "../dog";
+import Branch from "./Branch.vue";
+import { useCache } from "./util";
+
+export default defineComponent({
+  components: {
+    Branch,
+  },
+  setup() {
+    const randomImageUrlCache = useCache<string>();
+    populateCache(randomImageUrlCache, getRandomImageUrl());
+
+    const displayableImageUrl = computed(() => {
+      const { isLoading, data, error } = randomImageUrlCache.cache;
+      try {
+        if (data && !(isLoading || error)) {
+          return new URL(data);
+        }
+      } catch (err) {
+        console.log(err);
+      }
+      return null;
+    });
+
+    return { randomImageUrlCache, displayableImageUrl };
+  },
+});
+</script>

--- a/src/extra/components/util.ts
+++ b/src/extra/components/util.ts
@@ -1,0 +1,6 @@
+import { reactive } from "vue";
+import { initialiseCacheContainer } from "../cache";
+
+export function useCache<T>(initialData?: T) {
+  return reactive(initialiseCacheContainer(initialData));
+}

--- a/src/extra/dog.ts
+++ b/src/extra/dog.ts
@@ -1,0 +1,11 @@
+const dogApiUrl = "https://dog.ceo/api/breeds/image/random";
+
+export async function getRandomImageUrl() : Promise<string>{
+    const response = await fetch(dogApiUrl);
+    const {status} = response;
+    if (status === 200) {
+      const data = (await response.json()) as { message: string };
+      return data.message;
+    }
+    throw new Error(`Endpoint returned status ${status}`)
+}


### PR DESCRIPTION
This introduces a cache which 'tracks' a Promise and has well-defined states. 

In https://github.com/cefn/vite-reactive-repro/commit/d2e31c6c15a689942046042da030cb016e9e3545 that this PR is based on, we have the automatically-generated scaffolding and a prettier config added. 

The aim is to leave the main branch pointed at this common foundation, with multiple branches and draft PRs forking off this foundation with experiments and repros to share publically.

This Draft PR then adds a representative hierarchy of UI components which proves out the cache-based reactive mechanism intended to propagate state to UI. The additional source code for this feature is all in the [extra](https://github.com/cefn/vite-reactive-repro/tree/wire-cache-to-props/src/extra) folder.

The `<Root>` component triggers the retrieval of a URL, and has a tree of components below that assumes a reactive change to the cached URL will propagate through prop drilling.